### PR TITLE
Fixed issue with user profile images not displaying in comments section

### DIFF
--- a/app/src/main/java/com/example/instagram/PostCommentsActivity.kt
+++ b/app/src/main/java/com/example/instagram/PostCommentsActivity.kt
@@ -56,7 +56,7 @@ class PostCommentsActivity : AppCompatActivity() {
 
 
 
-
+        getImage()
         readComments(postid!!)
         getPostImage(postid!!)
 
@@ -88,9 +88,24 @@ class PostCommentsActivity : AppCompatActivity() {
         Toast.makeText(this, "posted!!", Toast.LENGTH_LONG).show()
     }
 
+    private fun getImage() {
+        val ref : DatabaseReference = FirebaseDatabase.getInstance().reference.child("Users").child(firebaseUser!!.uid)
 
+        ref.addValueEventListener(object: ValueEventListener {
+            override fun onCancelled(error: DatabaseError) {
 
+            }
 
+            override fun onDataChange(snapshot: DataSnapshot) {
+                if(snapshot.exists())
+                {
+                    val user = snapshot.getValue<User>(User::class.java)
+
+                    Picasso.get().load(user!!.getImage()).placeholder(com.example.instagram.R.drawable.profile).into(binding.userProfileImage)
+                }
+            }
+        })
+    }
 
     private fun pushNotification(postid: String) {
 


### PR DESCRIPTION
This pull request addresses the issue where user profile images were not displaying in the comments section. The problem was identified as an attempt to load an image URL from a potentially missing field in the User object retrieved from the Firebase Realtime Database.

Changes made:

- The code now checks if the User object exists in the onDataChange callback of the addValueEventListener.
- If the user exists, it attempts to retrieve the image URL from the getImage() method within the User class (assuming such a method exists).
- If the image URL is retrieved successfully, Picasso is used to load the image into the userProfileImage view.
- A placeholder image is displayed if the image URL is missing or fails to load.